### PR TITLE
Start a binary encoding document

### DIFF
--- a/proposals/module-linking/Binary.md
+++ b/proposals/module-linking/Binary.md
@@ -1,0 +1,219 @@
+# Module Linking Binary Format
+
+This document is intended to be a reference for the current state of the binary
+encoding of the module linking proposal. This is kept in sync with [the
+explainer](Explainer.md) and that is also recommended reading to understand this
+document. Currently this isn't striving to have a spec-level of detail, but
+hopefully it should be enough to get implementations off the ground and agreeing
+with each other!
+
+## Module-level updates
+
+At a high-level two new index spaces are added: modules and instances. Index
+spaces are also updated to be built incrementally as they are defined.
+
+Four new sections are added
+
+* Module section, `modulesec`, declares nested modules whose code comes
+  later. Only types are mentioned in this section.
+* Module Code section, `modulecodesec`, defines the nested modules.
+* Instance section, `instancesec`, declares and defines local instances.
+* Alias section, `aliassec`, brings in exports from nested instances or items
+  from the parent module into the local index space.
+
+The Type, Import, Module, Instance, and Alias sections can appear in any order
+at the beginning of a module. Each item defined in these sections can only refer
+to previously defined items. For example instance 4 cannot reference instance 5,
+and similarly no instance can refer to the module's own functions.
+
+## Type Section updates
+
+Updates to
+[`typesec`](https://webassembly.github.io/spec/core/binary/modules.html#binary-typesec):
+
+```
+typesec ::=  t*:section_1(vec(type))
+
+type ::=
+            0x60 ft:functype                    ->        ft
+            0x61 mt:moduletype                  ->        mt
+            0x62 it:instancetype                ->        it
+
+functype ::= rt_1:resulttype rt_2:resulttype    ->        rt_1 -> rt-2
+
+moduletype ::=
+  i*:vec(import) e*:vec(exporttype)             ->        {imports i, exports e}
+
+instancetype ::= e*:vec(exporttype)             ->        {exports e}
+
+exporttype ::= nm:name d:importdesc             ->        {name nm, desc d}
+```
+
+referencing:
+
+* [`resulttype`](https://webassembly.github.io/spec/core/binary/types.html#binary-resulttype)
+* [`import`](https://webassembly.github.io/spec/core/binary/modules.html#binary-import)
+
+**Validation**
+
+* each `importdesc` is valid according to import section
+* Types can only reference preceding type definitions. This forces everything to
+  be a DAG and forbids cyclic types.
+
+## Import Section updates
+
+Updates to
+[`importdesc`](https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc)
+
+```
+# note that `0x01 0xc0` in MVP-wasm specifies a 1-byte module field of the
+# string 0xc0, but the 0xc0 byte is not valid utf-8, so this was not a valid
+# MVP import
+import ::=
+    ...
+    mod:name  0x01 0xc0 d:importdesc            ->    {module mod, desc d}
+
+importdesc ::=
+    ...
+    0x05 x:typeidx                              ->    module x
+    0x06 x:typeidx                              ->    instance x
+```
+
+The `import` production is modified to allow optionally dropping the `name`
+field. This is done by encoding an invalid utf-8 string so this is an invalid
+MVP import.
+
+**Validation**
+
+* the `func x` production ensures the type `x` is indeed a function type
+* the `module x` production ensures the type `x` is indeed a module type
+* the `instance x` production ensures the type `x` is indeed an instance type
+
+## Module section (100)
+
+A new module section is added
+
+```
+modulesec ::=  t*:section_100(vec(typeidx))           ->        t*
+```
+
+**Validation**
+
+* Each type index `t` points to a module type (e.g. not a function type)
+* This defines the locally defined set of modules, adding to the module index
+  space.
+
+## Instance section (101)
+
+A new section defining local instances
+
+```
+instancesec ::=  i*:section_101(vec(instancedef))     ->    i*
+
+instancedef ::= m:moduleidx e*:vec(exportdesc)        ->    {instantiate m, imports e}
+```
+
+This defines instances in the module, appending to the instance index space.
+Each instance definition declares the module it's instantiating as well as the
+items used to instantiate that instance.
+
+**Validation**
+
+* The type index `m` must point to a module type.
+* The length of `e*` must be the same as the number of imports the module type
+  has
+* The type of each element of `e*` must be a subtype of the type that it's being
+  matched with. Matching happens pairwise with the list of imports on the module
+  type for `m`.
+* Indices of items referred to by `exportdesc` are all in-bounds. Can only refer
+  to imports/previous aliases, since only those sections can precede.
+
+## Alias section (102)
+
+A new module section is added
+
+```
+aliassec ::=  a*:section_102(vec(alias))     ->        a*
+
+alias ::=
+    0x00 i:instanceidx 0x00 e:exportidx      ->       (alias (instance $i) (func $e))
+    0x00 i:instanceidx 0x01 e:exportidx      ->       (alias (instance $i) (table $e))
+    0x00 i:instanceidx 0x02 e:exportidx      ->       (alias (instance $i) (memory $e))
+    0x00 i:instanceidx 0x03 e:exportidx      ->       (alias (instance $i) (global $e))
+    0x00 i:instanceidx 0x05 e:exportidx      ->       (alias (instance $i) (module $e))
+    0x00 i:instanceidx 0x06 e:exportidx      ->       (alias (instance $i) (instance $e))
+    0x01 0x04 m:moduleidx                    ->       (alias parent (module $m))
+    0x01 0x07 t:typeidx                      ->       (alias parent (type $t))
+```
+
+**Validation**
+
+* Aliased instance indexes are all in bounds
+* Aliased instance export indices are in bounds relative to the instance
+* Export indices match the actual type of the export
+* Aliases append to the respective index space
+
+## Function section
+
+**Validation**
+
+* Type indices must point to function types.
+
+## Export section
+
+update
+[`exportdesc`](https://webassembly.github.io/spec/core/binary/modules.html#binary-exportdesc)
+
+```
+exportdesc ::=
+    ...
+    0x05 x:moduleidx                        -> module x
+    0x06 x:instanceidx                      -> instance x
+```
+
+**Validation**
+
+* Module/instance indexes must be in-bounds.
+
+## Module Code Section (103)
+
+```
+modulecodesec ::= m*:section_103(vec(modulecode))       ->    m*
+
+modulecode ::= size:u32 mod:module                      ->    mod, size = ||mod||
+```
+
+Note that this is intentionally a recursive production where `module` refers to
+the top-level
+[`module`](https://webassembly.github.io/spec/core/binary/modules.html#binary-module)
+
+**Validation**
+
+* Module definitions must match their module type exactly, no subtyping (or
+  maybe subtyping, see WebAssembly/module-linking#9).
+* Modules themselves validate recursively.
+* Must have the same number of modules as the count of all local module
+  sections.
+
+## Subtyping
+
+Subtyping will extend what's currently ["import
+matching"](https://webassembly.github.io/spec/core/exec/modules.html#import-matching)
+
+**Instances**
+
+Instance `{exports e1}` is a subtype of `{exports e2}` if and only if:
+
+* Each name in `e1` is present in `e2`
+* For each corresponding name `n` in the sets
+  * `e1[n]` is a subtype of `e2[n]`
+
+**Instances**
+
+Module `{imports i1, exports e1}` is a subtype of `{imports i2, exports e2}` if and only if:
+
+* Each name in `e1` is present in `e2`
+* For each corresponding name `n` in the sets
+  * `e1[n]` is a subtype of `e2[n]`
+* ... And some condition on imports. For now this is a bit up for debate on
+  WebAssembly/module-linking#7

--- a/proposals/module-linking/Binary.md
+++ b/proposals/module-linking/Binary.md
@@ -123,13 +123,16 @@ the future we'll likely want this binary value to match that.
 **Validation**
 
 * The type index `m` must point to a module type.
-* The length of `e*` must be the same as the number of imports the module type
-  has.
-* The type of each element of `e*` must be a subtype of the type that it's being
-  matched with. Matching happens pairwise with the list of imports on the module
-  type for `m`.
 * Indices of items referred to by `exportdesc` are all in-bounds. Can only refer
   to imports/previous aliases, since only those sections can precede.
+* The precise rules of how `e*` is validated against the module type's declare
+  list of imports is being hashed out in
+  [#7](https://github.com/WebAssembly/module-linking/issues/7). For now
+  conservative order-dependent rules are used where the length of `e*` must be
+  the same as the number of imports the module type has. Additionally the type
+  of each element of `e*` must be a subtype of the type that it's being matched
+  with. Matching happens pairwise with the list of imports on the module type
+  for `m`.
 
 ## Alias section (102)
 
@@ -159,6 +162,12 @@ alias ::=
 * Parent aliases can only happen in submodules (not the top-level module) and
   the index specifies is the entry, in the parent's raw index space, for that
   item.
+* Parent aliases can only refer to preceeding module/type definitions, relative
+  to the binary location where the inline module's type was declared. Note that
+  when the module code section is defined all of the parent's modules/types are
+  available, but inline modules still may not have access to all of these if the
+  items were declared after the module's type in the corresponding module
+  section.
 
 ## Function section
 


### PR DESCRIPTION
This PR is intended to start discussion around a binary format for
module linking. This isn't supposed to be a final format nor is it even
sufficient for spec-level documentation. The hope though is that this
can be used as a basis for coordinating across the tooling ecosystem to
ensure there's a plan of record of what to implement as well as a place
for discussions.