### PR TITLE
Change alias sugar, remove local indices, give module/instance types fresh index spaces

### DIFF
--- a/proposals/module-linking/Binary.md
+++ b/proposals/module-linking/Binary.md
@@ -153,9 +153,14 @@ A new module section is added
 aliassec ::=  a*:section_16(vec(alias))     ->        a*
 
 alias ::=
-    0x00 i:instanceidx nm:name              ->       (alias (* $i nm))
-    0x01 ct:varu32 0x05 m:moduleidx         ->       (alias (module outer ct m))
-    0x01 ct:varu32 0x07 t:typeidx           ->       (alias (type outer ct t))
+    0x00 i:instanceidx 0x00 nm:name         ->        (alias (func $i "nm"))
+    0x00 i:instanceidx 0x01 nm:name         ->        (alias (table $i "nm"))
+    0x00 i:instanceidx 0x02 nm:name         ->        (alias (memory $i "nm"))
+    0x00 i:instanceidx 0x03 nm:name         ->        (alias (global $i "nm"))
+    0x00 i:instanceidx 0x05 nm:name         ->        (alias (module $i "nm"))
+    0x00 i:instanceidx 0x06 nm:name         ->        (alias (instance $i "nm"))
+    0x01 ct:varu32 0x05 m:moduleidx         ->        (alias (module outer ct m))
+    0x01 ct:varu32 0x07 t:typeidx           ->        (alias (type outer ct t))
 ```
 
 **Validation**
@@ -164,9 +169,8 @@ alias ::=
   means only those definitions preceding this alias definition in binary format
   order. In the case of outer aliases, this means the position of the nested module
   definition in the outer module.
-* Aliased instance export names must be found in the instance `$i`.
-* For instance export aliases, the index space into which the alias is
-  injected is determined by the definition kind of the named export.
+* Aliased instance export names must be found in `i`'s instance type with a
+  matching definition kind.
 * The `ct` of an outer alias must be *less than* the number of enclosing modules
   which implicitly prevents outer aliases from appearing in top-level modules.
 

--- a/proposals/module-linking/Binary.md
+++ b/proposals/module-linking/Binary.md
@@ -35,22 +35,30 @@ Updates to
 typesec ::=  t*:section_1(vec(type))
 
 type ::=
-            0x60 ft:functype                    ->        ft
-            0x61 mt:moduletype                  ->        mt
-            0x62 it:instancetype                ->        it
+            0x60 ft:functype                     ->       ft
+            0x61 mt:moduletype                   ->       mt
+            0x62 it:instancetype                 ->       it
 
-functype ::= rt_1:resulttype rt_2:resulttype    ->        rt_1 -> rt-2
+functype     ::= rt_1:resulttype rt_2:resulttype ->       rt_1 -> rt-2
+moduletype   ::= mtd*:vec(moduletypedef)         ->       mtd*
+instancetype ::= itd*:vec(instancetypedef)       ->       itd*
 
-moduletype ::=
-  i*:vec(import) e*:vec(exporttype)             ->        {imports i*, exports e*}
+moduletypedef ::=
+            itd                                  ->       itd
+            0x02 i:import                        ->       {import i}
 
-instancetype ::= e*:vec(exporttype)             ->        {exports e*}
+instancetypedef ::=
+            0x01 t:type                          ->       {type t}
+            0x07 et:exporttype                   ->       {export et}
+            0x0f a:alias                         ->       {alias a}
 
-exporttype ::= nm:name d:importdesc             ->        {name nm, desc d}
+exporttype ::= nm:name d:importdesc              ->       {name nm, desc d}
 ```
 
-referencing:
+Note: the numeric discriminants in `moduletypedef` are chosen to match the
+section numbers for the corresponding sections.
 
+Referencing:
 * [`resulttype`](https://webassembly.github.io/spec/core/binary/types.html#binary-resulttype)
 * [`import`](https://webassembly.github.io/spec/core/binary/modules.html#binary-import)
 * [`importdesc`](https://webassembly.github.io/spec/core/binary/modules.html#binary-importdesc) -
@@ -58,7 +66,10 @@ referencing:
 
 **Validation**
 
-* each `importdesc` is valid according to import section
+* The `moduletypedef`s of a `moduletype` are validated in a fresh set of index
+  spaces (currently, only the type index space is used). Thus, the function
+  type of a function export must either be defined inside the `moduletype` or
+  aliased. The same goes for `instancetypedef`s and `instancetype`s.
 * Types can only reference preceding type definitions. This forces everything to
   be a DAG and forbids cyclic types. TODO: with type imports we may need cyclic
   types, so this validation will likely change in some form.

--- a/proposals/module-linking/Binary.md
+++ b/proposals/module-linking/Binary.md
@@ -153,14 +153,14 @@ A new module section is added
 aliassec ::=  a*:section_16(vec(alias))     ->        a*
 
 alias ::=
-    0x00 i:instanceidx 0x00 nm:name         ->        (alias (func $i "nm"))
-    0x00 i:instanceidx 0x01 nm:name         ->        (alias (table $i "nm"))
-    0x00 i:instanceidx 0x02 nm:name         ->        (alias (memory $i "nm"))
-    0x00 i:instanceidx 0x03 nm:name         ->        (alias (global $i "nm"))
-    0x00 i:instanceidx 0x05 nm:name         ->        (alias (module $i "nm"))
-    0x00 i:instanceidx 0x06 nm:name         ->        (alias (instance $i "nm"))
-    0x01 ct:varu32 0x05 m:moduleidx         ->        (alias (module outer ct m))
-    0x01 ct:varu32 0x07 t:typeidx           ->        (alias (type outer ct t))
+    0x00 i:instanceidx 0x00 nm:name         ->        (alias $i "nm" (func))
+    0x00 i:instanceidx 0x01 nm:name         ->        (alias $i "nm" (table))
+    0x00 i:instanceidx 0x02 nm:name         ->        (alias $i "nm" (memory))
+    0x00 i:instanceidx 0x03 nm:name         ->        (alias $i "nm" (global))
+    0x00 i:instanceidx 0x05 nm:name         ->        (alias $i "nm" (module))
+    0x00 i:instanceidx 0x06 nm:name         ->        (alias $i "nm" (instance))
+    0x01 ct:varu32 0x05 m:moduleidx         ->        (alias outer ct m (module))
+    0x01 ct:varu32 0x07 t:typeidx           ->        (alias outer ct m (type))
 ```
 
 **Validation**

--- a/proposals/module-linking/Example-LinkTimeVirtualization.md
+++ b/proposals/module-linking/Example-LinkTimeVirtualization.md
@@ -64,8 +64,8 @@ We can now write the parent module by composing `$VIRTUALIZE` and `$CHILD`:
     (export "play" (func))
   ))
 
-  (instance $virt-wasi (instantiate $VIRTUALIZE "wasi_file" (instance $real-wasi)))
-  (instance $child (instantiate $CHILD "wasi_file" (instance $virt-wasi)))
+  (instance $virt-wasi (instantiate $VIRTUALIZE (import "wasi_file" (instance $real-wasi))))
+  (instance $child (instantiate $CHILD (import "wasi_file" (instance $virt-wasi))))
 
   (func (export "work")
     ...

--- a/proposals/module-linking/Example-LinkTimeVirtualization.md
+++ b/proposals/module-linking/Example-LinkTimeVirtualization.md
@@ -8,16 +8,14 @@ We start with a child module that has been written and compiled separately,
 without regard to the parent module. It imports `wasi_file` to do file I/O:
 
 ```wasm
-;; child.wat
-(module
-  (type $WasiFile (instance
-    (export "read" (func $read (param i32 i32 i32) (result i32)))
-    (export "write" (func $write (param i32 i32 i32) (result i32)))
+(module $CHILD
+  (import "wasi_file" (instance $wasi-file
+    (export "read" (func (param i32 i32 i32) (result i32)))
+    (export "write" (func (param i32 i32 i32) (result i32)))
   ))
-  (import "wasi_file" (instance $wasi-file (type $WasiFile)))
   (func $play (export "play")
     ...
-    call $wasi-file.$read
+    call (func $wasi-file "read")
     ...
   )
 )
@@ -31,8 +29,11 @@ as a separate module that imports a "real" `wasi_file` instance and uses it
 to implement a new virtualized `wasi_file` instance:
 
 ```wasm
-;; virtualize.wat
-(module
+(module $VIRTUALIZE
+  (type $WasiFile (instance
+    (export "read" (func (param i32 i32 i32) (result i32)))
+    (export "write" (func (param i32 i32 i32) (result i32)))
+  ))
   (import "wasi_file" (instance $wasi-file (type $WasiFile)))
 
   (func (export "read") (param i32 i32 i32) (result i32)
@@ -44,44 +45,41 @@ to implement a new virtualized `wasi_file` instance:
 )
 ```
 
-We can now write the parent module by composing `virtualize.wasm` and
-`child.wasm` appropriately:
+We can now write the parent module by composing `$VIRTUALIZE` and `$CHILD`:
 
 ```wasm
-;; parent.wat
-(module
+(module $PARENT
   (type $WasiFile (instance
-    (export "read" (func $read (param i32 i32 i32) (result i32)))
-    (export "write" (func $write (param i32 i32 i32) (result i32)))
+    (export "read" (func (param i32 i32 i32) (result i32)))
+    (export "write" (func (param i32 i32 i32) (result i32)))
   ))
   (import "wasi_file" (instance $real-wasi (type $WasiFile)))
 
-  (import "./virtualize.wasm" (module $VIRTUALIZE
-    (import "wasi_file" (instance (type $WasiFile)))
-    (export $WasiFile)
+  (import "virtualize" (module $VIRTUALIZE
+    (import "wasi_file" (instance (type outer $PARENT $WasiFile)))
+    (export (type outer $PARENT $WasiFile))
   ))
-  (import "./child.wasm" (module $CHILD
-    (import "wasi_file" (instance (type $WasiFile)))
+  (import "child" (module $CHILD
+    (import "wasi_file" (instance (type outer $PARENT $WasiFile)))
     (export "play" (func))
   ))
 
-  (instance $virt-wasi (instantiate $VIRTUALIZE (instance $real-wasi)))
-  (instance $child (instantiate $CHILD (instance $virt-wasi)))
+  (instance $virt-wasi (instantiate $VIRTUALIZE "wasi_file" (instance $real-wasi)))
+  (instance $child (instantiate $CHILD "wasi_file" (instance $virt-wasi)))
 
   (func (export "work")
     ...
-    call $child.$play
+    call (func $child "play")
     ...
   )
 )
 ```
 
 Here, we assume the host understands relative file paths, but we could also bundle
-all 3 files into one compound `parent-bundle.wasm`:
+all 3 files into one compound `$PARENT-BUNDLE` module:
 
 ```wasm
-;; parent-bundled.wat
-(module
+(module $PARENT-BUNDLE
   (type $WasiFile     ...same as above)
   (import "wasi_file" ...same as above)
 

--- a/proposals/module-linking/Explainer.md
+++ b/proposals/module-linking/Explainer.md
@@ -607,7 +607,7 @@ inline-alias syntax is extended to allow a sequence of N export names:
   (import "i" (instance $i
     (export "j" (instance
       (export "k" (func))))))
-  (func (call (func $i "j" "k" "l")))
+  (func (call (func $i "j" "k")))
 )
 ```
 which desugars to:

--- a/proposals/module-linking/Explainer.md
+++ b/proposals/module-linking/Explainer.md
@@ -348,15 +348,15 @@ accessed by creating an *alias*:
     (export "f1" (func))
     (export "f2" (func (param i32)))
   ))
-  (alias (func $f $i "f1"))
+  (alias $f (func $i "f1"))
   (func (export "run")
     call $f
   )
 )
 ```
 This `alias` definition adds the `f1` export of the import `$i` into the
-function index space of the module so that it may later be referenced by
-instructions like `call`.
+function index space of the module so that it may later be referenced via
+the identifier/index `$f` by instructions like `call`.
 
 As syntactic sugar, aliases may be created implicitly via a new form of
 syntactic sugar:
@@ -454,9 +454,9 @@ example, the following module (with desugared aliases) is valid:
 (module
   (import "a" (instance $a (export "f" (func))))
   (import "b" (module $B (import "g" (func)) (export "h" (func))))
-  (alias (func $a.f $a "f"))
+  (alias $a.f (func $a "f"))
   (instance $b1 (instantiate $B "g" (func $a.f)))
-  (alias (func $b1.h $b1 "h"))
+  (alias $b1.h (func $b1 "h"))
   (instance $b2 (instantiate $B "g" (func $b1.h)))
 )
 ```
@@ -516,7 +516,7 @@ instance type:
   ))
   (import "fileops" (instance $fileops (type $FileOps)))
   (module $CHILD
-    (alias (type $FOps outer $PARENT $FileOps))
+    (alias $FOps (type outer $PARENT $FileOps))
     (import "fileops" (instance $fops (type $FOps)))
     ...
   )
@@ -616,8 +616,8 @@ which desugars to:
   (import "i" (instance $i
     (export "j" (instance
       (export "k" (func))))))
-  (alias (instance $j $i "j"))
-  (alias (func $k $j "k"))
+  (alias $j (instance $i "j"))
+  (alias $k (func $j "k"))
   (func (call $k))
 )
 ```

--- a/proposals/module-linking/Explainer.md
+++ b/proposals/module-linking/Explainer.md
@@ -358,6 +358,12 @@ This `alias` definition adds the `f1` export of the import `$i` into the
 function index space of the module so that it may later be referenced via
 the identifier/index `$f` by instructions like `call`.
 
+[Similar to imports][func-import-abbrev], aliases can also be written in
+an inverted form that puts the definition kind first:
+```wasm
+(func $f (alias $i "f1"))  ;; ≡ (alias $i "f1" (func $f))
+```
+
 As syntactic sugar, aliases may be created implicitly via a new form of
 syntactic sugar:
 ```wasm
@@ -829,6 +835,7 @@ transparently share library code as described in
 [`importdesc`]: https://webassembly.github.io/spec/core/syntax/modules.html#syntax-importdesc
 [`exportdesc`]: https://webassembly.github.io/spec/core/syntax/modules.html#syntax-exportdesc
 [`module` binary format production]: https://webassembly.github.io/spec/core/binary/modules.html#binary-module
+[func-import-abbrev]: https://webassembly.github.io/spec/core/text/modules.html#text-func-abbrev
 
 [Shared-Nothing Linking]: https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md#enabling-shared-nothing-linking-of-webassembly-modules
 [Interface Types]: https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md

--- a/proposals/module-linking/Explainer.md
+++ b/proposals/module-linking/Explainer.md
@@ -205,8 +205,8 @@ Thus, this proposal enriches the existing **module type** by adding names
 to imports and exports.
 
 Thus far, module types only appear as an internal detail of the wasm spec; they
-aren't explicitly represented in the text format. This proposal additionally
-gives module types a text format parse rule.
+aren't explicitly represented in the text or binary format. This proposal
+additionally gives module types a text and binary format representation.
 
 The module type text format is derived from the existing module definition text
 format (extended with single-level imports) by simply dropping all internal
@@ -235,7 +235,7 @@ has a module type:
 )
 ```
 Just as with module definitions, the above module type is actually an
-[abbreviation][import-abbrev] in the text format for:
+[abbreviation] in the text format for:
 ```wasm
 (module
   (import "a" (memory 1 2))
@@ -244,16 +244,16 @@ Just as with module definitions, the above module type is actually an
   (export "d" (func (result f32)))
 )
 ```
-which is primarily used in this proposal.
 
 Although module types list imports and exports in a particular order, module
-*subtyping* allows a supplied module definition's to have a different order as
-long as all the fields are present. Moreover, module subtyping is covariant in
-exports and contravariant in imports (including allowing a subtype to have more
-exports and fewer imports than its supertype). These permissive subtyping rules
-provide modules additional flexibility to evolve without breaking existing
-clients. Since module types are checked at instantiation-time, this extra
-flexibility shouldn't affect runtime performance.
+*subtyping* allows a supplied module definition's imports and exports to have a
+different order as long as all the fields are present. Moreover, module
+subtyping is covariant in exports and contravariant in imports (including
+allowing a subtype to have more exports and fewer imports than its supertype).
+These permissive subtyping rules provide modules additional flexibility to
+evolve without breaking existing clients. Since module types are checked at
+instantiation-time, this extra flexibility shouldn't affect runtime
+performance.
 
 In WebAssembly there is also the separate concept of a module *instance*,
 which is the result of [instantiating][Module Instantiation] a module with
@@ -271,16 +271,15 @@ Like module types, the exports of an instance type are ordered, but instance
 subtyping allows arbitrary reordering and compatible extension.
 
 Just like function types, module and instance types can either be written
-"inline" or factored out into an explicit type definition that can be reused via
-`$identifier`. (Also, just like function types, the inline form is an
-[abbreviation][typeuse-abbrev] for an implicit type definition and use.) For
-example, an instance type can be defined:
+inline or factored out into an explicit type definition that can be reused via
+`$identifier`. For example, an instance type can be defined:
 ```wasm
 (type $WasiFile (instance
   (export "read" (func (param i32 i32 i32) (result i32)))
   (export "write" (func (param i32 i32 i32) (result i32)))
 ))
 ```
+and then reused later via `(type $WasiFile)`.
 
 In many examples shown below, type definitions are needed for *both* a module
 type and the instance type produced when that module type is instantiated. In
@@ -317,8 +316,8 @@ an instance type:
 ```wasm
 (module
   (import "i" (instance $i
-    (export "f1" (func $f1))
-    (export "f2" (func $f2 (param i32)))
+    (export "f1" (func))
+    (export "f2" (func (param i32)))
   ))
 )
 ```
@@ -329,8 +328,8 @@ immutable record containing the addresses of its fields in the store) there
 should be no semantic difference between the previous module and this next one:
 ```wasm
 (module
-  (import "i" "f1" (func $f1))
-  (import "i" "f2" (func $f2 (param i32)))
+  (import "i" "f1" (func))
+  (import "i" "f2" (func (param i32)))
 )
 ```
 
@@ -342,57 +341,58 @@ appear at the position of the first of its fields.) Thus, the above two modules
 both parse and decode to the same abstract syntax.
 
 From inside a module definition, the exports of an imported instance can be
-accessed with an identifier path:
+accessed by creating an *alias*:
 ```wasm
 (module
   (import "i" (instance $i
-    (export "f1" (func $f1))
-    (export "f2" (func $f2 (param i32)))
+    (export "f1" (func))
+    (export "f2" (func (param i32)))
   ))
+  (alias (func $f $i "f1"))
   (func (export "run")
-    call $i.$f1
+    call $f
   )
 )
 ```
-Identifier paths like `$i.$f1` are actually syntactic sugar for creating
-a new kind of definition added by this proposal called an `alias`. A desugared
-version of the same module can be written:
+This `alias` definition adds the `f1` export of the import `$i` into the
+function index space of the module so that it may later be referenced by
+instructions like `call`.
+
+As syntactic sugar, aliases may be created implicitly via a new form of
+syntactic sugar:
 ```wasm
 (module
   (import "i" (instance $i
-    (export "f1" (func $f1))
-    (export "f2" (func $f2 (param i32)))
+    (export "f1" (func))
+    (export "f2" (func (param i32)))
   ))
-  (alias $i.$f1 (instance $i) (func $f1))
   (func (export "run")
-    call $i.$f1
+    call (func $i "f1")
   )
 )
 ```
-`alias` definitions allow a module to inject definitions from other places into
-its own index spaces. In this case, the `alias` injects the `f1` export
-of `i` into the module's function index space. Repeated uses of the same
-`$i.$f1` path would reuse the same alias. Thus, path desugaring is symmetric to
-how multiple uses of inline function types [desugar][typeuse-abbrev] to the same
-function type definition.
+The expression `(func $i "f1")` adds a new `alias` definition if an equivalent
+one doesn't exist. (This is symmetric to how a [`typeuse`] works for function
+types.) Thus the above two modules would produce the same abstract syntax and
+binary encoding. This new inline-alias form is allowed everywhere an index or
+identifier is allowed currently.
 
 Aliases are not restricted to functions: all exportable definitions can be
 aliased. One situation where an explicit `alias` definition may be required is
-for a default memory or table since if there is no explicit `$i.$j` path used
-by instructions to refer to defaults, they must be explicitly aliased:
+for a default memory or table:
 ```wasm
 (module
   (import "libc" (instance $libc
-    (export "memory" (memory $mem 1))
-    (export "table" (table $tbl 0 funcref))
+    (export "mem" (memory 1))
+    (export "tbl" (table 0 funcref))
   ))
-  (alias (instance $libc) (memory $mem)) ;; memory index 0 = default memory
-  (alias (instance $libc) (table $tbl)) ;; table index 0 = default table
+  (alias (memory $libc "mem"))  ;; aliases "mem" at memory index 0 (= default)
+  (alias (table $libc "tbl"))   ;; aliases "tbl" at table index 0 (= default)
   (func
     ...
-    i32.load  ;; accesses $libc.$mem
+    i32.load  ;; accesses the default memory, $libc.mem
     ...
-    table.get ;; accesses $libc.$tbl
+    table.get ;; accesses the default table, $libc.tbl
     ...
   )
 )
@@ -400,16 +400,14 @@ by instructions to refer to defaults, they must be explicitly aliased:
 
 The benefit of instance imports is that they allow potentially-large groups of
 fields to be passed around as a single unit, which can be useful when linking
-significant dependencies. Also, practically, instance imports allow import
-strings to be factored in the text and binary formats, reducing duplication.
-
+significant dependencies. Also, practically, instance imports allow the
+module-name strings to be factored out in the text and binary formats.
 
 ### Module Imports and Nested Instances
 
-A module can similarly be imported by declaring the expected module type. Unlike
-instance imports, once a module is imported, it must be instantiated by the
-client before it can be executed. This is achieved by creating *nested
-instances* via `instance` definitions. For example, in this code:
+A module can similarly be imported by declaring the expected module type. Once
+a module is imported, it can be instantiated with an `instance` definition. For
+example, in this code:
 ```wasm
 (module
   (import "M" (module $M
@@ -417,18 +415,20 @@ instances* via `instance` definitions. For example, in this code:
     (export "out" (func $out))
   ))
   (import "f" (func $f))
-  (instance $i (instantiate $M (func $f)))
+  (instance $i (instantiate $M "in" (func $f)))
   (func (export "run")
-    call $i.$out
+    call (func $i "out")
   )
 )
 ```
-the outer module imports a module `$M` and a function `$f` and then uses `$f` to
-instantiate `$M` producing an instance `$i`. `instance` definitions have the form:
+the outer module imports a module `$M` and a function `$f` and then
+instantiates `$M`, passing `$f` for the import `in` and producing a fresh
+instance `$i`. `instance` definitions have the form:
 ```
 instance-def  ::= (instance <id>? <instance-init>)
-instance-init ::= (instantiate <moduleidx> <instance-arg>*)
-instance-arg  ::= (func <funcidx>)
+instance-init ::= (instantiate <moduleidx> <import-arg>*)
+import-arg    ::= <name> <import-val>
+import-val    ::= (func <funcidx>)
                 | (memory <memidx>)
                 | (table <tableidx>)
                 | (global <globalidx>)
@@ -436,24 +436,21 @@ instance-arg  ::= (func <funcidx>)
                 | (module <moduleidx>)
 ```
 where `<instanceidx>` and `<moduleidx>` are indices into the new module
-and instance [index spaces] created by module/instance imports/definitions. In
-the future, new productions could be added to `<instance-init>` allowing
+and instance [index spaces] created by module/instance imports/definitions.
+Validation requires that every `<name>` imported by `<moduleidx>` is satisfied
+by an `<import-arg>` with a matching `<name>`. Validation also requires all
+`<import-arg>` `<name>`s to be unique. Symmetric to the module subtyping rules
+described above, superfluous `<name>`s are valid.
+
+In the future, new productions could be added to `<instance-init>` allowing
 alternatives to `instantiate` for creating instances, such as directly from
 fields without an intermediate module.
-
-Validation requires that the sequence of `import-arg`s match the declared
-import args of `<moduleidx>` based on the order of imports in `<moduleidx>`'s
-module type definition. As mentioned in [Module and Instance Types](#module-and-instance-types),
-module subtyping (checked at instantiation time for `$M`) allows the actual
-imported module to have compatible imports and exports in any order. Thus,
-`instance` statements do not impose any ordering requirements on the actual
-imported modules.
 
 Instances can also be supplied as arguments to `instantiate`, allowing whole
 collections of fields to be passed as a single unit. For example, this module
 imports a `wasi_file` instance and passes it on to the child:
 ```wasm
-(module
+(module $PARENT
   (type $WasiFile (instance
     (export "read" (func (param i32 i32 i32) (result i32)))
     (export "write" (func (param i32 i32 i32) (result i32)))
@@ -461,40 +458,40 @@ imports a `wasi_file` instance and passes it on to the child:
   ))
   (import "wasi_file" (instance $wasi-file (type $WasiFile)))
   (import "child" (module $CHILD
-    (import "wasi_file" (instance (type $WasiFile)))
+    (import "wasi_file" (instance (type outer $PARENT $WasiFile)))
   ))
-  (instance (instantiate $CHILD (instance $wasi-file)))
+  (instance (instantiate $CHILD "wasi_file" (instance $wasi-file)))
 )
 ```
 
 In general, the arguments of `instantiate` can refer to any preceding type,
 import, module, instance or alias definition. This includes all imports and
 the local definitions that precede the `instantiate` in module order. For
-example, the following module (with desugared aliases) validates:
+example, the following module (with desugared aliases) is valid:
 ```wasm
 (module
-  (import "a" (instance $a (export "f" (func $f))))
-  (import "B" (module $B (import "f" (func)) (export "g" (func $g))))
-  (alias $a.f (func $a $f))
-  (instance $b1 (instantiate $B (func $a.f)))
-  (alias $b1.g (func $b1 $g))
-  (instance $b2 (instantiate $B (func $b1.g)))
+  (import "a" (instance $a (export "f" (func))))
+  (import "b" (module $B (import "g" (func)) (export "h" (func))))
+  (alias (func $a.f $a "f"))
+  (instance $b1 (instantiate $B "g" (func $a.f)))
+  (alias (func $b1.h $b1 "h"))
+  (instance $b2 (instantiate $B "g" (func $b1.h)))
 )
 ```
 Notably, `instantiate` cannot refer to any local function, memory, table or
 global definitions. The reason for this is that, when instantiating a module
 `M`, the nested instances of `M` are created before the [`moduleinst`] of `M`
 itself and, thus, local function, memory, table and global definitions do not
-exist when the nested instances are created. Thus, for example, the following
-module wouldn't validate.
+exist when the nested instances are created. For example, the following module
+is not valid:
 ```wasm
 (module
   (import "A" (module $A (import "f" (func))))
-  (func $f)
-  (instance $a (instantiate $A (func $f))) ;; error, $f not visible to instantiate
+  (func $g ...)
+  (instance $a (instantiate $A "f" (func $g))) ;; error, $g not visible to instantiate
 )
 ```
-From the perspective of a WebAssembly [Embedding], this proposal changes
+From the perspective of a WebAssembly [embedding], this proposal changes
 [`module_instantiate`]`(M)` from always creating a single `moduleinst` to
 instead creating a DAG of `moduleinst`s, with `M`'s `moduleinst` as the returned
 root.
@@ -508,13 +505,13 @@ space as module imports and thus can be instantiated the same way. For example:
 ```wasm
 (module
   (module $CHILD
-    (func $hi (export "hi")
+    (func (export "hi")
       ...
     )
   )
   (instance $child (instantiate $CHILD))
   (func (export "run")
-    call $child.$hi
+    call (func $child "hi")
   )
 )
 ```
@@ -522,39 +519,36 @@ space as module imports and thus can be instantiated the same way. For example:
 Unlike most source-language nested functions/classes, nested modules have no
 special access to their parents' state. However, since modules and types are
 closed, stateless expressions which would otherwise be duplicated, sharing is
-allowed between children and parents via module and type aliases.
+allowed between children and parents via a new kind of `outer` alias:
+```wasm
+(module $PARENT
+  (type $WasiFile (instance $wasi-file
+    (export "read" (func (param i32 i32 i32) (result i32)))
+  ))
+  (module $CHILD
+    (alias (type $WasiFile outer $PARENT $WasiFile))
+    (import "wasi_file" (instance (type $WasiFile)))
+  )
+)
+```
+Just like for instance-export aliases, a new form of inline sugar for outer
+aliases:
+```wasm
+(module $PARENT
+  (type $WasiFile (instance $wasi-file
+    (export "read" (func (param i32 i32 i32) (result i32)))
+  ))
+  (module $CHILD
+    (import "wasi_file" (instance (type outer $PARENT $WasiFile)))
+  )
+)
+```
+Thus, the above two modules produce the same abstract syntax and binary
+representation.
 
-For convenience in the text format, a module can directly use the identifier of
-an enclosing module's type or module definitions:
-```wasm
-(module
-  (type $WasiFile (instance $wasi-file
-    (export "read" (func (param i32 i32 i32) (result i32)))
-  ))
-  (module $child
-    (import "wasi_file" (instance (type $WasiFile)))
-  )
-)
-```
-This gets desugared into an explicit `alias` definition adding an entry to
-the child's type index space:
-```wasm
-(module
-  (type $WasiFile (instance $wasi-file
-    (export "read" (func (param i32 i32 i32) (result i32)))
-  ))
-  (module $child
-    (alias $WasiFile parent (type $WasiFile))
-    (import "wasi_file" (instance (type $WasiFile)))
-  )
-)
-```
-Note that `parent` aliases can only refer to previously-defined items relative
-to the module's own declaration in the module index space. This means that it
-can refer to previously defined imports, modules, instances, or aliases, but it
-cannot refer to imports (for example) that occur after the module's
-declaration. A module is declared with its type and defined later in the binary
-format.
+Outer aliases in a nested module can only refer to definitions in outer modules
+that precede it. This is necessary to ensure that type and module definitions
+are not cyclic across module boundaries.
 
 In general, language-independent tools can easily merge multiple `.wasm` files
 in a dependency graph into one `.wasm` file by performing simple transformations
@@ -589,6 +583,28 @@ be exported. For example:
 Therefore, module and instance types can appear in both the imports and exports
 of module types and instance types.
 
+Consequently, instances can be nested N levels deep. Correspondingly, the
+inline-alias syntax is extended to allow a sequence of N export names:
+```wasm
+(module
+  (import "i" (instance $i
+    (export "j" (instance
+      (export "k" (func))))))
+  (func (call (func $i "j" "k" "l")))
+)
+```
+which desugars to:
+```wasm
+(module
+  (import "i" (instance $i
+    (export "j" (instance
+      (export "k" (func))))))
+  (alias (instance $j $i "j"))
+  (alias (func $k $j "k"))
+  (func (call $k))
+)
+```
+
 Symmetric to the "zero-level export" mentioned [above](#module-and-instance-types)
 which is allowed in module *types*, zero-level exports are also allowed in
 module *definitions* as a convenient way to define a module's exports to be
@@ -597,7 +613,7 @@ that of a given instance.
 For example, this (outer) module:
 ```wasm
 (module
-  (module $M (func (export "foo") ..))
+  (module $M (func (export "foo") ...))
   (instance $i (instantiate $M))
   (export $i)
 )
@@ -646,13 +662,13 @@ Sections.
 As an example, the text module:
 ```wasm
 (module
-  (import "a" (instance $a (export "f" (func $f))))
+  (import "a" (instance $a (export "f" (func))))
   (module $M
-    (import "f" (func))
-    (export "g" (func $g)))
-  (instance $m1 (instantiate $M (func $a.$f)))
-  (instance $m2 (instantiate $M (func $m1.$g)))
-  (func $x (call $m2.$g))
+    (import "g" (func))
+    (func (export "h")))
+  (instance $m1 (instantiate $M "g" (func $a "f")))
+  (instance $m2 (instantiate $M "g" (func $m1 "h")))
+  (func $x (call (func $m2 "h")))
 )
 ```
 could be encoded with the binary section sequence:
@@ -660,13 +676,16 @@ could be encoded with the binary section sequence:
 2. Import Section, defining the import `$a`, referencing (1)
 3. Module Section, defining the module `$M`, which is allowed to alias the
    parent module's `[]->[]` function type (referencing (1))
-4. Alias Section, injecting `$a.$f` into the function index space, referencing (2)
+4. Alias Section, injecting the `f` export of `$a` into the function index
+   space, referencing (2)
 5. Instance Section, defining the instance `$m1`, referencing (3) and (4)
-6. Alias Section, injecting `$m1.$g` into the function index space, referencing (5)
+6. Alias Section, injecting the `g` export of `$m1` into the function index
+   space, referencing (5)
 7. Instance Section, defining the instance `$m2`, referencing (3) and (6)
-8. Alias Section, injecting `$m2.$g` into the function index space, referencing (7)
+8. Alias Section, injecting the `g` export of `$m2` into the function index
+   space, referencing (7)
 9. Function Section, declaring `$x` in the function index space, referencing (1)
-10. Code Section, defining `$x`, referencing (9)
+10. Code Section, defining `$x`
 
 This repository also contains an [initial proposal for the binary format
 updates](./Binary.md).
@@ -676,8 +695,7 @@ updates](./Binary.md).
 
 To summarize the proposed changes (all changes in both text and binary format):
 * The `module` field of [`import`] becomes optional (allowing single-level
-  imports). (How to encode this in the [Import Section] is an interesting
-  question.)
+  imports).
 * New `module` and `instance` type constructors are added that may be used to
   define types in the [type section].
 * New `module` and `instance` cases are added to [`importdesc`], referencing
@@ -777,8 +795,8 @@ transparently share library code as described in
 [JS API]: https://webassembly.github.io/spec/js-api/index.html
 [`instantiate`]: https://webassembly.github.io/spec/js-api/index.html#dom-webassembly-instantiate-moduleobject-importobject
 [Module Validation]: https://webassembly.github.io/spec/core/valid/modules.html#valid-module
-[import-abbrev]: https://webassembly.github.io/spec/core/text/modules.html#id1
-[typeuse-abbrev]: https://webassembly.github.io/spec/core/text/modules.html#abbreviations
+[Abbreviation]: https://webassembly.github.io/spec/core/text/conventions.html#abbreviations
+[`typeuse`]: https://webassembly.github.io/spec/core/text/modules.html#type-uses
 [Module Instantiation]: https://webassembly.github.io/spec/core/exec/modules.html#instantiation
 [WAT]: https://webassembly.github.io/spec/core/text/conventions.html#conventions
 [Indices]: https://webassembly.github.io/spec/core/syntax/modules.html#indices

--- a/proposals/module-linking/Subtyping.md
+++ b/proposals/module-linking/Subtyping.md
@@ -160,28 +160,23 @@ Some examples of valid modules are:
 
 ## Instantiation
 
-Instantiation primarily occurs via name-based resolution (e.g. in the JS API and
-other language embeddings) or position-based resolution (e.g. embedded engines).
+Within WebAssembly, instantiation is similar to subtyping: the `instantiate`
+caller (either from the JS API or an `(instance)` definition) supplies a
+sequence of (name, value) pairs and the imports of the module being
+instantiated are checked against this list, ignoring order and just matching on
+names. As with module import subtyping, the `instantiate` caller may supply
+superfluous names that are ignored and duplicate names are not allowed.
 
-It's expected that the original import list of a module is retained to map
-positional-based resolution to name-based resolution. With positional-based
-resolution imports would need to be provided as-is with the module in question
-(no sugar applied where you can supply an instance for a function import). This
-enables the engine to transform a list of imports into a map from import name to
-an instance with exports.
+While two-level imports are desugared into single-level imports of instances,
+no such desugaring is performed by `instantiate` from within WebAssembly:
+two-level imports simply do not exist and imports of instances must be passed
+instances. This is backwards-compatible since, before this proposal, only the
+JS API's `WebAssembly.instantiate` existed, which already behaved in the
+desired way.
 
-Name-based resolution wouldn't need to change too too much, it would allow
-top-level names to be defined with actual wasm instances or further host-defined
-maps of strings. Instance imports could then be satisfied with maps-of-strings
-so long as all the strings line up. Note that the `instantiate` instruction is
-expected to use named-based instantiation.
-
-In both cases instantiation is intended to become primarily name-based. This
-matches the intended behavior of the `instantiate` instruction in a wasm module
-which is to name all the provided items according to the declared module type
-that's being instantiated. This also enables embedders to work with instances
-supplied to satisfy a list of function imports. For example embedders would take
-a singular "wasi instance" to satisfy all wasi function imports from a module.
+WebAssembly *embeddings* may however choose to flatten imports of instances
+into lists of imports of the instances' fields, preserving backwards
+compatibility and avoiding the need to create intermediate instances.
 
 ## Breaking change?!
 


### PR DESCRIPTION
This PR addresses issues #19 and #20 by:
* removing the use of local indices (into local module/instance typedefs) in `alias` and `instantiate`; instead, `<name>`s are used:
  * `(alias $f (func $instance "export"))` with inline sugar `(func $instance "export")`
  * `(instance $i (instantiate $M "foo" (instance $foo) "bar" (func $bar)))`
    * Note: I used a flat list of `<name> <instance-arg>` because I couldn't think of a concrete reason to introduce a more verbose syntax that explicitly grouped them (e.g., `(arg <name> <instance-arg>)`), but I'm open to hearing other thoughts.
* renaming "parent" to "outer" alias
* adding an explicit outer module to outer aliases that can be *any* enclosing module:
  * `(alias $t (type outer $PARENT $Type))` with inline sugar `(type outer $PARENT $Type)`

Although it isn't explicitly called out in the current explainer, these changes remove the need to add `$identifier` names to module/instance types.  Updating all the code examples, I found this a nice change, removing what always had felt like a superfluous name for each imported module's/instance's export.