### PR TITLE
Change outer alias count to start at the current module

### DIFF
--- a/design/proposals/module-linking/Binary.md
+++ b/design/proposals/module-linking/Binary.md
@@ -127,11 +127,11 @@ Notes:
 * For instance-export aliases, `i` is validated to refer to an instance in the
   instance index space that actually exports `nm` with the specified definition
   kind.
-* For outer aliases, `ct` is validated to be *less than* the number of enclosing
-  modules and `i` is validated to be a valid index in the specified
-  definition's index space of the enclosing adapter module indicated by `ct`
-  (counting outward, starting with `0` referring to the immediately-enclosing
-  adapter module).
+* For outer aliases, `ct` is validated to be *less or eqeual than* the number
+  of enclosing modules and `i` is validated to be a valid index in the
+  specified definition's index space of the enclosing adapter module indicated
+  by `ct` (counting outward, starting with `0` referring to the current adapter
+  module).
 
 
 ## Type Definitions

--- a/design/proposals/module-linking/Binary.md
+++ b/design/proposals/module-linking/Binary.md
@@ -127,7 +127,7 @@ Notes:
 * For instance-export aliases, `i` is validated to refer to an instance in the
   instance index space that actually exports `nm` with the specified definition
   kind.
-* For outer aliases, `ct` is validated to be *less or eqeual than* the number
+* For outer aliases, `ct` is validated to be *less or equal than* the number
   of enclosing modules and `i` is validated to be a valid index in the
   specified definition's index space of the enclosing adapter module indicated
   by `ct` (counting outward, starting with `0` referring to the current adapter

--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -544,7 +544,10 @@ aliases `$Outer`'s `$Libc` module, avoiding the need to manually import it:
 ```
 Here, `$Outer` and `$Libc` serve as symbolic [de Bruijn indices], ultimately
 resolving to a pair of integers: the number of enclosing adapter modules to
-skip, and the index of the target definition.
+skip, and the index of the target definition. In particular, this number can be
+0, in which case the outer alias refers to the current module, allowing a
+single module to alias its own definitions at multiple indices in the index
+space (which can be [useful to tools][Issue-30]).
 
 Adapter module definitions containing outer aliases effectively produce a
 module [closure] at instantiation time, including a copy of the outer-aliased
@@ -908,3 +911,5 @@ import Foo from "./foo.wasm" as "wasm-module";
 [Figma plugins]: https://www.figma.com/blog/an-update-on-plugin-security/
 [Attenuate]: http://cap-lore.com/CapTheory/Patterns/Attenuation.html
 [Default Export]: https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#Description
+
+[Issue-30]: https://github.com/WebAssembly/module-linking/issues/30


### PR DESCRIPTION
With the refactoring out of the way, this PR addresses #30 by changing the outer alias count to start at the current module.  As @fitzgen noted, this can be useful to tools.  Also, it's totally already expressible with auxiliary modules+instances, so it's "nothing new".