### PR TITLE
Nuance the handling of imports in ESM-integration

### DIFF
--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -878,17 +878,7 @@ two-level imports with existing ESM-integration. Since the exports of an
 instance type can themselves be instance types, this process must be performed
 recursively.
 
-For imports of type `(global externref)` (i.e., an immutable core WebAssembly
-global storing a value of type `externref`), the imported Module Record is
-first converted to a [Namespace Object] via [`GetModuleNamespace()`] and then
-converted to a `(global externref)` as a normal JavaScript value. This allows
-the importing adapter module to dynamically access the fields of the
-Namespace Object by calling other imported functions (such as `Object.get()`).
-In the future, other compatible types (e.g., `handle` Interface Types) could be
-included in this case.
-
-Otherwise, if the import cannot accept a Namespace Object (and would error
-otherwise), the import is treated like a JavaScript [Imported Default Binding]
+Otherwise, the import is treated like a JavaScript [Imported Default Binding]
 and the Module Record is converted to its default value. This allows, for
 example, a single level import of a function:
 ```wasm

--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -909,7 +909,6 @@ objects for exports as described above for the JS API.
 [Module Record]: https://tc39.es/ecma262/#sec-abstract-module-records
 [Module Specifier]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-ModuleSpecifier
 [Named Imports]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-NamedImports
-[`GetModuleNamespace()`]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace
 [Imported Default Binding]: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-ImportedDefaultBinding
 
 [Core Concepts]: https://webassembly.github.io/spec/core/intro/overview.html#concepts

--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -833,6 +833,10 @@ WebAssembly.instantiateStreaming(fetch('./a.wasm'), {
 where `instantiateStreaming` checks that the module created from `code` exports
 a function `six` (and *may* import a function `five`).
 
+Additionally, the JS API `WebAssembly.Module.imports()` and `exports()`
+functions would need to be extended to include the new instance and module
+types in the `kind` fields.
+
 Lastly, considering the new exportable types, a module export would naturally
 produce a `WebAssembly.Module` object. For an instance export, the JavaScript
 correspondence already established by [ESM-integration] is a [Namespace Object].


### PR DESCRIPTION
This PR attempts to incorporate Guy's ideas in #32.  Already the line suggested to be removed was removed by #35.  This PR adds the idea suggested in the final comments saying that single-level imports start out with Module Records, and then perform the default-value conversion when needed, thereby allowing adapter modules to directly import Namespace Objects if they want.

I also realized that, in terms of case analysis, the "module import" case goes first because it doesn't start with a Module Record (which iiuc is the "instance" of the ESM world); it asks the ESM loader for a totally different (new) thing.