### PR TITLE
Fixed typo in superfluous imports example

### DIFF
--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -455,7 +455,7 @@ superfluous export `d` being ignored by `$M`.
 ```wasm
 (adapter module
   (adapter module $M
-    (import "superfluous" (module
+    (import "i" (module
       (import "a" (func))
       (import "b" (func))
       (export "c" (func))

--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -455,14 +455,14 @@ superfluous export `d` being ignored by `$M`.
 ```wasm
 (adapter module
   (adapter module $M
-    (import "i" (module
+    (import "superfluous" (module
       (import "a" (func))
       (import "b" (func))
       (export "c" (func))
     ))
   )
   (module $N
-    (import "b" (func))
+    (import "i" "b" (func))
     (func (export "c") ...)
     (func (export "d") ...)
   )

--- a/design/proposals/module-linking/Explainer.md
+++ b/design/proposals/module-linking/Explainer.md
@@ -461,8 +461,8 @@ superfluous export `d` being ignored by `$M`.
       (export "c" (func))
     ))
   )
-  (module $N
-    (import "i" "b" (func))
+  (adapter module $N
+    (import "b" (func))
     (func (export "c") ...)
     (func (export "d") ...)
   )


### PR DESCRIPTION
I am not sure if this is an error, but from my understanding in superfluous import example, `$N` is a core module, therefore `import` must be of the form `(import <string> <string> (func ...)`. If that is the case the example is missing the first `<string>`.

Is my understanding correct?